### PR TITLE
fix: Invalid response verification for Get HTTP requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -314,7 +314,36 @@ module.exports = class {
                     await delay(2000)
                     continue
                 }
-                if(!result || !result.janus === "success") {
+                if(!result ||
+                    result.janus === "error" ||
+                    (result.janus === "success" &&
+                        result.plugindata &&
+                        result.plugindata.data &&
+                        result.plugindata.data.error &&
+                        result.plugindata.data.error_code
+                    )
+                ) {
+                    if (result) {
+                        let plugin = false
+                        let reason
+                        if (result.error) {
+                            reason = result.error.reason
+                        }
+                        if (!reason && result.plugindata && result.plugindata.data) {
+                            reason = result.plugindata.data.error
+                        }
+                        let code
+                        if (result.error) {
+                            code = result.error.code
+                        }
+                        if (!code && result.plugindata && result.plugindata.data) {
+                            code = result.plugindata.data.error_code
+                            plugin = true
+                        }
+                        console.log(
+                            `Err Janus ${plugin ? "plugin Videoroom" : ""} [(${code}) ${reason}]`
+                        )
+                    }
                     console.log('Err polling janus videoRoom ['+err+"/2]")
                     err ++
                     await delay(2000)


### PR DESCRIPTION
There was an error in the condition '!result.janus === "success"', which always returned false.
'!result.janus' evaluates to false, and false !== "success".
Parentheses need to be added to make the condition valid.

However, Janus doesn't only return "success" but also "event", "webrtcup", "media", and "ack".
We will now check for the presence of an error in the request and log the error code and cause.

JSON structure for core Janus error responses:
{
    "janus": "error",
    "error": {
        "code": 423,
        "reason": "test cause"
    }
}

JSON structure for plugin Janus error responses:
{
    "janus": "success",
    "plugindata": {
        "data": {
            "error_code": 411,
            "error": "plugin test error"
        }
    }
}